### PR TITLE
Hot fix for 1.12 support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 			    </repository>
                 <repository>
 	                   <id>vault-repo</id>
-	                   <url>http://nexus.theyeticave.net/content/repositories/pub_releases</url>
+	                   <url>http://nexus.hc.to/content/repositories/pub_releases</url>
                </repository>
         </repositories>
         <dependencies>
@@ -20,14 +20,14 @@
 			    <dependency>
 			           <groupId>org.spigotmc</groupId>
 			           <artifactId>spigot-api</artifactId>
-			           <version>1.10-R0.1-SNAPSHOT</version>
+			           <version>1.12-R0.1-SNAPSHOT</version>
 			           <scope>provided</scope>
 			    </dependency>
 			    <!--Bukkit API-->
 			    <dependency>
 			            <groupId>org.bukkit</groupId>
 			            <artifactId>bukkit</artifactId>
-			            <version>1.10-R0.1-SNAPSHOT</version>
+			            <version>1.12-R0.1-SNAPSHOT</version>
 			            <scope>provided</scope>
 			    </dependency>
             

--- a/src/com/ebiggz/postalservice/config/ConfigAccessor.java
+++ b/src/com/ebiggz/postalservice/config/ConfigAccessor.java
@@ -3,6 +3,7 @@ package com.ebiggz.postalservice.config;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
@@ -33,7 +34,7 @@ public class ConfigAccessor {
 		// Look for defaults in the jar
 		InputStream defConfigStream = plugin.getResource(fileName);
 		if (defConfigStream != null) {
-			YamlConfiguration defConfig = YamlConfiguration.loadConfiguration(defConfigStream);
+			YamlConfiguration defConfig = YamlConfiguration.loadConfiguration(new InputStreamReader(defConfigStream));
 			fileConfiguration.setDefaults(defConfig);
 			try {
 				//fileConfiguration.save(configFile);


### PR DESCRIPTION
It just a simple fix for supporting Bukkit / Spigot 1.12 due to changes of APIs. This fix will not work with 1.11 or lower, though you can still add some version detection into ConfigAccessor.java for backward capabilities.